### PR TITLE
Add support for iPad

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import preventEvent from './lib/prevent-event';
 import proxyProperty from './lib/proxy-property';
 import Symbol from './lib/poor-mans-symbol';
 
-const isNeeded = /iPhone|iPod/i.test(navigator.userAgent);
+const isNeeded = /iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 const ಠ = Symbol('iiv');
 const ಠevent = Symbol('iive');


### PR DESCRIPTION
Is there a reason why iPad was not supported in the library? Videos are playing fine on my iPad.