### PR TITLE
Make sure a time is passed to Intervalometer#start()

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function play() {
 	}
 
 	player.driver.play();
-	player.updater.start();
+	player.updater.start(0);
 
 	video.dispatchEvent(new Event('play'));
 


### PR DESCRIPTION
It appears a bug has been introduced as of version 1.6.0 (with 1.5.0 it works fine, I have checked).

When – by code – triggering a `.play()` of video the value of `now` in `Intervalometer#start()` is `undefined`, yielding a value of `NaN` to be injected into the `cb` callback. 

- The netto result in the console is that an error is spit out: `Uncaught TypeError: Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.`
- The netto result on screen is that videos don't load properly in MobileSafari on iOS9 (a black screen is rendered instead) after the error is encountered.

This PR makes sure that a `time` of `0` is passed into `Intervalometer#start()` when `$video.play()` is called.