### PR TITLE
Reset source on currentSrc change

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,12 @@ function play() {
 		return;
 	}
 
+	if (player.driver.src !== video.currentSrc) {
+		player.driver.pause();
+		player.paused = true;
+		player.driver.src = video.currentSrc;
+	}
+
 	if (!video.paused) {
 		return;
 	}


### PR DESCRIPTION
This is somewhat related to the `currentSrc`-related PR I made earlier. If I call `play()` on a video element without a source, then change its `src`, and then call `play()` again, the source won't be synced with the audio element.