### PR TITLE
Only dispatch playback events if audio is playable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import Intervalometer from './lib/intervalometer';
 import preventEvent from './lib/prevent-event';
 import proxyProperty from './lib/proxy-property';
+import proxyEvent from './lib/proxy-event';
 import Symbol from './lib/poor-mans-symbol';
 
 const isWhitelisted = /iPhone|iPod/i.test(navigator.userAgent);
@@ -17,6 +18,9 @@ const ಠpause = Symbol('nativepause');
 
 function getAudioFromVideo(video) {
 	const audio = new Audio();
+	proxyEvent(video, 'play', audio);
+	proxyEvent(video, 'playing', audio);
+	proxyEvent(video, 'pause', audio);
 	audio.src = video.currentSrc || video.src;
 	audio.crossOrigin = video.crossOrigin;
 	return audio;
@@ -86,10 +90,12 @@ function play() {
 	player.driver.play();
 	player.updater.start();
 
-	video.dispatchEvent(new Event('play'));
+	if (!player.hasAudio) {
+		video.dispatchEvent(new Event('play'));
 
-	// TODO: should be fired later
-	video.dispatchEvent(new Event('playing'));
+		// TODO: should be fired later
+		video.dispatchEvent(new Event('playing'));
+	}
 }
 function pause(forceEvents) {
 	// console.log('pause')
@@ -111,7 +117,9 @@ function pause(forceEvents) {
 	}
 
 	player.paused = true;
-	video.dispatchEvent(new Event('pause'));
+	if (!player.hasAudio) {
+		video.dispatchEvent(new Event('pause'));
+	}
 	if (video.ended) {
 		video[ಠevent] = true;
 		video.dispatchEvent(new Event('ended'));

--- a/lib/proxy-event.js
+++ b/lib/proxy-event.js
@@ -1,0 +1,4 @@
+'use strict';
+export default function proxyEvent(object, eventName, sourceObject) {
+	sourceObject.addEventListener(eventName, () => object.dispatchEvent(new Event(eventName)));
+}


### PR DESCRIPTION
Currently `play` event is dispatched also in cases, where the audio element is not user-initiated. I propose proxying playback events from the audio element to the video element.