### PR TITLE
Allow loading in Node.js without setting up jsdom

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import proxyProperty from './lib/proxy-property';
 import proxyEvent from './lib/proxy-event';
 import dispatchEventAsync from './lib/dispatch-event-async';
 
-const iOS8or9 = 'object-fit' in document.head.style && !matchMedia('(-webkit-video-playable-inline)').matches;
+const iOS8or9 = typeof document === 'object' && 'object-fit' in document.head.style && !matchMedia('(-webkit-video-playable-inline)').matches;
 
 const ಠ = 'bfred-it:iphone-inline-video';
 const ಠevent = 'bfred-it:iphone-inline-video:event';


### PR DESCRIPTION
Hey, thanks for the great lib, very useful!

This PR adds a tiny fix when checking for iOS 8 or 9. By checking if `document` exists at all, it allows loading `iphone-inline-video` in tests (Node.js) without setting up `jsdom`. 

Avoids this:

```
var isWhitelisted = 'object-fit' in document.head.style && /iPhone|iPod/i.test(navigator.userAgent) && !matchMedia('(-webkit-video-playable-inline)').matches;
                                    ^

ReferenceError: document is not defined
```